### PR TITLE
Add output archival script

### DIFF
--- a/scripts/cleanup_output/README.md
+++ b/scripts/cleanup_output/README.md
@@ -44,11 +44,23 @@ The input and output paths are set via the following options in the `archive_run
 ```bash
 EXPT_DIR=           # cylc run directory for experiment to be archived
 ARCHIVE_DIR=        # Directory for writing the archived data
-startyear=1981      # First year to archive
-endyear=1981        # Last year to archive
 ```
 
 Note that the script will fail on incomplete years of output. 
+
+`archive_run.sh` converts a single year of output, specified as an argument during the `qsub` call:
+
+```
+qsub -v YEAR=<year> archive_run.sh
+```
+
+To archive several years in an experiment, this can be run in a loop:
+```
+for year in {1981..2030}
+do
+qsub -v YEAR=$year archive_run.sh
+done
+```
 
 By default, coupler history files `access-cm3.cpl.h.*.nc` are not archived. These can also be archived
 by adding the flag `--cpl` to the line

--- a/scripts/cleanup_output/archive-run.sh
+++ b/scripts/cleanup_output/archive-run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-#PBS -l ncpus=8
-#PBS -l mem=60GB
+#PBS -l ncpus=48
+#PBS -l mem=192GB
 #PBS -q normal
 #PBS -P tm70
 #PBS -l walltime=03:00:00
@@ -11,13 +11,10 @@
 module use /g/data/xp65/public/modules
 module load conda/analysis3
 
-EXPT_DIR=           # cylc run directory for experiment to be archived
-ARCHIVE_DIR=        # Directory for writing the archived data
-startyear=1981      # First year to archive
-endyear=1981        # Last year to archive
+EXPT_DIR=          # cylc run directory for experiment to be archived
+ARCHIVE_DIR=       # Directory for writing the archived data
+#startyear=
 
+echo "Year $YEAR"
 
-for ((year=startyear;year<=endyear;year++)); do
-echo "Year: $year"
-python cleanup_output.py -y $year -e $EXPT_DIR -a $ARCHIVE_DIR
-done
+python cleanup_output.py -y $YEAR -e $EXPT_DIR -a $ARCHIVE_DIR

--- a/scripts/cleanup_output/cleanup_output.py
+++ b/scripts/cleanup_output/cleanup_output.py
@@ -134,7 +134,7 @@ def move_ocean(year, work_dirs, ocean_archive_dir):
     # - 1D variables combined into single file
     file_patterns = {
         "native": rf"access-cm3\.mom6.h\.native_{year}_([0-9]{{2}})\.nc",
-        "sfc": rf"access-cm3\.mom6\.h\.sfc_{year}_([0-9]{{2}})\.nc",
+        # "sfc": rf"access-cm3\.mom6\.h\.sfc_{year}_([0-9]{{2}})\.nc",
         "z": rf"access-cm3\.mom6\.h\.z_{year}_([0-9]{{2}})\.nc"
     }
     for output_type, pattern in file_patterns.items():
@@ -204,7 +204,10 @@ def move_ocean(year, work_dirs, ocean_archive_dir):
         for path in filepaths:
             check_exists(path)
         print("Saving ocean variables")
-        xr.save_mfdataset(datasets, filepaths)
+
+        for dataset, filepath in groups_to_save:
+            dataset.load().to_netcdf(filepath)
+        # xr.save_mfdataset(datasets, filepaths)
 
 
 def is_scalar_var(dims):
@@ -302,7 +305,7 @@ def parse_cell_methods(methods_string):
 
 
 def move_ice(work_dirs, ice_archive_dir):
-    pattern = r"access-cm3\.cice\.(?!r)"
+    pattern = r"access-cm3\.cice\.1mon\.(?!r)"
     datasets = []
     output_paths = []
     for dir in work_dirs:


### PR DESCRIPTION
Closes #61

This PR adds a rudimentary archival script for CM3 output data, for use while there's no automatic archival done at the end of a simulation. 

The script was used to archive the long 1 degree run in `/g/data/zv30/non-cmip/ACCESS-CM3/cm3-run-29-01-2025-exp-runoff-smoothing-rmax-500-efold-1000`. I've updated it to work with the new filenames and dates from the OM3 beta config changes.